### PR TITLE
Fix #2 by overriding Node#inspect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ Style/DotPosition:
   EnforcedStyle: trailing
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
+
+# Overwrite Hound default
+Style/StringLiterals:
+  EnforcedStyle: single_quotes

--- a/lib/aho_corasick_matcher.rb
+++ b/lib/aho_corasick_matcher.rb
@@ -95,5 +95,9 @@ class AhoCorasickMatcher
 
       failure
     end
+
+    def inspect
+      format('#<%s:0x%x', self.class.name, object_id << 1)
+    end
   end
 end

--- a/spec/aho_corasick_matcher_spec.rb
+++ b/spec/aho_corasick_matcher_spec.rb
@@ -78,4 +78,12 @@ RSpec.describe AhoCorasickMatcher do
       ).to eq(%w(Test TestString String Test))
     end
   end
+
+  describe '#inspect' do
+    let(:dict) { ('aaa'...'bbb').to_a }
+
+    it 'does not include instance variables to prevent stack explosions' do
+      expect(matcher.inspect).not_to include('@child_map')
+    end
+  end
 end


### PR DESCRIPTION
Override the default inspect implementation for an
AhoCorasickMatcher::Node instance to no longer include its instance
variables. This prevents `Stack level too deep` errors as the contents
of Nodes can require large amounts of recursion to inspect.
